### PR TITLE
Set Terminal profile on Travis to 'Basic'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ rvm: system
 install:
   - sudo gem install bundler --no-ri --no-rdoc
   - sudo ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future bundle install
+  - defaults write com.apple.Terminal 'Default Window Settings' Basic
 script:
   - bundle exec rake ci


### PR DESCRIPTION
Travis VMs currently default to the 'Pro' profile, which is what our
integration tests are trying to set to.
